### PR TITLE
Fixed build error for HelloWorld example.  ('String?' must be unwrapped)

### DIFF
--- a/HelloWorld-CMake/Source/HelloWorld/HelloWorld.swift
+++ b/HelloWorld-CMake/Source/HelloWorld/HelloWorld.swift
@@ -14,7 +14,7 @@ func display(_ message: String) -> Bool {
 
 func main() {
   let accessor: HelloWorldStringAccessor = HelloWorldStringAccessor()
-  guard let message = try? accessor.access(), display(message) else {
+  guard let message = try? accessor.access(), display(message!) else {
     print("unable to display message")
     return
   }


### PR DESCRIPTION
When I was building / exploring the samples, I found that I the HelloWorld sample would fail with the following: 

`HelloWorld\HelloWorld.swift:17:55: error: value of optional type 'String?' must be unwrapped to a value of type 'String'
  guard let message = try? accessor.access(), display(message) else {
                                                      ^
C:\repos\swift-build-examples\HelloWorld-CMake\Source\HelloWorld\HelloWorld.swift:17:55: note: coalesce using '??' to provide a default when the optional value contains 'nil'
  guard let message = try? accessor.access(), display(message) else {
                                                      ^
                                                              ?? <#default value#>
C:\repos\swift-build-examples\HelloWorld-CMake\Source\HelloWorld\HelloWorld.swift:17:55: note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
  guard let message = try? accessor.access(), display(message) else {
                                                      ^
                                                             !`

