### PR TITLE
HelloWorldCore: add a dependency on a C library

### DIFF
--- a/HelloWorld-CMake/Source/HelloWorldCore/CMakeLists.txt
+++ b/HelloWorld-CMake/Source/HelloWorldCore/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(HelloWorldCore
   HelloWorldCore.swift)
 target_compile_options(HelloWorldCore PRIVATE
   $<$<BOOL:BUILD_TESTING>:-enable-testing>)
+target_link_libraries(HelloWorldCore PRIVATE
+  CCore)
 set_target_properties(HelloWorldCore PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 

--- a/HelloWorld-CMake/Source/HelloWorldCore/HelloWorldCore.swift
+++ b/HelloWorld-CMake/Source/HelloWorldCore/HelloWorldCore.swift
@@ -1,7 +1,14 @@
 
+@_implementationOnly
+import CCore
+
 public struct HelloWorldCore {
   public static var string: String {
     return _HelloWorldCore.string
+  }
+
+  public static var version: String {
+    return "\(CGetVersionMajor()).\(CGetVersionMinor()).\(CGetVersionPatch())"
   }
 }
 


### PR DESCRIPTION
This adds a dependency on a C library to demonstrate how to integrate a
C library into a Swift library.