### PR TITLE
Interop: Set Swift interop flag for Xcode 15

### DIFF
--- a/Interop/Sources/Swift/Executable/CMakeLists.txt
+++ b/Interop/Sources/Swift/Executable/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(E
   E.swift)
 target_compile_options(E PRIVATE
-  -enable-experimental-cxx-interop)
+  -cxx-interoperability-mode=default)
 target_link_libraries(E PRIVATE
   cxx_library)


### PR DESCRIPTION
In the Xcode 15 Beta, the swiftc compiler no longer accepts the experimental version of this flag.

I tested that this works with Xcode 15.0 beta 5 (15A5209g)

I did run into issues getting the interop to work in the Xcode GUI when trying to use C++20, and posted a question on the apple developer forums here: https://developer.apple.com/forums/thread/735186

Curious whether you have any feedback on that :D